### PR TITLE
Fix "main" statement in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "good-winston-json",
   "version": "0.0.1",
   "description": "good winston reporter with structured JSON output ",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Currently, the main statement doesn't point to the right place. 
We need to do `require('good-winston-json/lib');` to make it work :/
